### PR TITLE
Parameterize serial port for the config script

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,12 +301,9 @@ ssh登录进入debian系统后执行以下命令：
 
      ls -al /dev/
 
-使用识别的设备名称替换 configuration_klipper_family.sh 内的 ttyACM0
+使用识别的设备名称执行： 
 
-
-然后重新执行： 
-
-	bash configuration_klipper_family.sh
+	bash configuration_klipper_family.sh -p "识别的设备名称"
 
 
 祝大家每一次3D打印都能成功！！！

--- a/README_en.md
+++ b/README_en.md
@@ -269,7 +269,7 @@ Replace ttyACM0 in configuration_klipper_family.sh with the recognized device na
 
 Then re-execute:
 
-      bash configuration_klipper_family.sh
+	bash configuration_klipper_family.sh -p "recognized device name"
 
 
 I wish you every success in 3D printing! ! !

--- a/configuration_klipper_family.sh
+++ b/configuration_klipper_family.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+serial_port="/dev/ttyACM0"
+while getopts p: flag
+do
+    case "${flag}" in
+        p) serial_port=${OPTARG};;
+    esac
+done
+
+echo "Using serial port ${serial_port}"
+
 if [ "$(id  -u)" = "0" ]
 then
   echo "Start script as user!"
@@ -12,7 +22,7 @@ then
   exit 1
 fi
 
-if [ ! -c "/dev/ttyACM0" ] 
+if [ ! -c "$serial_port" ] 
 then
   echo "Please connect your phone to the printer "
   exit 1
@@ -89,7 +99,7 @@ sudo tee "$TTYFIX" <<EOF
 inotifywait -m /dev -e create |
   while read dir action file
   do
-    [ "\$file" = "ttyACM0" ] && chmod 777 /dev/ttyACM0
+    [ "\$file" = "ttyACM0" ] && chmod 777 $serial_port
   done
 EOF
 sudo chmod +x "$TTYFIX"
@@ -194,7 +204,7 @@ PIDFILE=/var/run/klipper.pid
 [ -r \$DEFAULTS_FILE ] && . \$DEFAULTS_FILE
 
 case "\$1" in
-start)  chmod 777 /dev/ttyACM0
+start)  chmod 777 $serial_port
         log_daemon_msg "Starting" \$NAME
         start-stop-daemon --start --quiet --exec \$KLIPPY_EXEC \\
 		                  --background --pidfile \$PIDFILE --make-pidfile \\


### PR DESCRIPTION
Instead of letting user modify the script everytime, why don't we parameterize the serial port while keeping a default value of `"/dev/ttyACM0"` 😃 .

Example use case:
```
bash configuration_klipper_family.sh -p "/home/android/octo4a/serialpipe"
```

I am not very familiar with bash script, feel free to modify.